### PR TITLE
refactor: Cambié el end point /api/v1/comics/:id/rent.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Kata: Alquiler de Comics. :books:
 
 
-Willian tiene una tienda donde alquila historietss usadas,
+Willian tiene una tienda donde alquila historietas usadas,
 donde su costo depende de su precio de compra menos un descuento
 por el estado del ejemplar: excelente (10%), bueno (20%), aceptable (25%),
 deteriorado (30%), dañado (50%).  
@@ -9,9 +9,9 @@ deteriorado (30%), dañado (50%).
 
 ## End Points disponibles :link:
 
-- Listado de comics: **GET** ***/api/v1/comics***
-- Listado de rentals: **GET** ***/api/v1/rentals***  
-- Alquilar una comic: **POST** ***/api/v1/comics/:id/rent***  
+- Listado de comics: **GET** ***/api/v1/comics/***
+- Listado de rentals: **GET** ***/api/v1/rentals/***  
+- Alquilar una comic: **POST** ***/api/v1/comics/:id/rentals/***  
   EL cuerpo de la petición tiene que ser:  
   ```
    {
@@ -46,3 +46,4 @@ deteriorado (30%), dañado (50%).
 - Python 3.8
 - Django
 - Django Rest Framework
+- Django Injector

--- a/apps/comics/infrastructure/dj/comicsapp/tests/test_views.py
+++ b/apps/comics/infrastructure/dj/comicsapp/tests/test_views.py
@@ -154,7 +154,7 @@ class RentComicAPIViewTest(APITestCase):
 
     @staticmethod
     def generate_url(for_id):
-        return '/api/v1/comics/{0}/rent/'.format(for_id)
+        return '/api/v1/comics/{0}/rentals/'.format(for_id)
     
     @staticmethod
     def generate_uuid():
@@ -191,7 +191,7 @@ class RentalListAPIViewTest(APITestCase):
         }
         comic = ComicFactory.create()
 
-        rent_url = "/api/v1/comics/{0}/rent/".format(comic.id)
+        rent_url = "/api/v1/comics/{0}/rentals/".format(comic.id)
         self.client.post(rent_url, data)
 
         response = self.client.get(self.url)

--- a/apps/comics/infrastructure/dj/comicsapp/urls.py
+++ b/apps/comics/infrastructure/dj/comicsapp/urls.py
@@ -7,6 +7,6 @@ app_name = 'comics'
 
 urlpatterns = [
     path('comics', views.ComicListAPIView.as_view(), name='index'),
-    path('comics/<int:pk>/rent/', views.ComicRentAPIView.as_view(), name='rent_comic'),
+    path('comics/<int:pk>/rentals/', views.ComicRentAPIView.as_view(), name='rent_comic'),
     path('rentals', views.RentalListAPIView.as_view(), name='rentals'),
 ]


### PR DESCRIPTION
Ahora el end point para alquilar un comic es:
POST /api/v1/comics/:id/rentals.

Esto se hizo para cumplir con los estanderes REST.